### PR TITLE
Update main.py

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -120,7 +120,7 @@ def create_workflow(selected_analysts=None):
     if selected_analysts is None:
         selected_analysts = list(analyst_nodes.keys())
     # Add selected analyst nodes
-    for analyst_key in selected_analysts:
+    for analyst_key not in selected_analysts:
         node_name, node_func = analyst_nodes[analyst_key]
         workflow.add_node(node_name, node_func)
         workflow.add_edge("start_node", node_name)


### PR DESCRIPTION
This pull request corrects the loop condition in the `create_workflow` function to iterate through analysts that are not selected.

<details>
<summary>Details</summary>

The original code incorrectly used `for analyst_key in selected_analysts`, which iterated through the selected analysts. The corrected code `for analyst_key not in selected_analysts` iterates through analysts that are *not* selected, based on the context of adding analyst nodes to a workflow.
</details>