### PR TITLE
Update main.py

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -28,8 +28,7 @@ from tabulate import tabulate
 from utils.visualize import save_graph_as_png
 import json
 
-# Load environment variables from .env file
-load_dotenv()
+
 
 init(autoreset=True)
 


### PR DESCRIPTION
This PR removes the dotenv loading from `src/main.py`. The environment variables are now handled differently, possibly through system environment variables or a different configuration mechanism.

<details>
<summary>File Changes</summary>

- Removed `load_dotenv()` from `src/main.py`.
- This indicates a shift in how environment variables are managed.
</details>