### PR TITLE
Update main.py

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -28,8 +28,7 @@ from tabulate import tabulate
 from utils.visualize import save_graph_as_png
 import json
 
-# Load environment variables from .env file
-load_dotenv()
+
 
 init(autoreset=True)
 


### PR DESCRIPTION
This PR removes the dotenv loading from `src/main.py`. The environment variables are now expected to be set directly in the environment where the application is deployed.

<details>
<summary>Rationale</summary>

*   The `load_dotenv()` line was removed, indicating a shift in how the application handles environment variables.
*   Environment variables are now expected to be set directly in the deployment environment.
</details>