### PR TITLE
Spartan dainguyen patch 2

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -28,8 +28,7 @@ from tabulate import tabulate
 from utils.visualize import save_graph_as_png
 import json
 
-# Load environment variables from .env file
-load_dotenv()
+
 
 init(autoreset=True)
 


### PR DESCRIPTION
This PR removes the `load_dotenv()` call from `src/main.py`.

<details><summary>Reasoning</summary>The `load_dotenv()` function, which loads environment variables from a `.env` file, is no longer needed in `main.py`.</details>